### PR TITLE
Add clarifying comment around pending tx subscriptions

### DIFF
--- a/block_engine.proto
+++ b/block_engine.proto
@@ -81,8 +81,9 @@ service BlockEngineValidator {
 /// Relayers can forward packets to Block Engines.
 /// Block Engines provide an AccountsOfInterest field to only send transactions that are of interest.
 service BlockEngineRelayer {
-  /// Relayers subscribe to a stream that contains a set of accounts they're interested in getting transactions for.
-  /// They receive periodic updates for those accounts
+  /// The block engine feeds accounts of interest (AOI) updates to the relayer periodically.
+  /// For all transactions the relayer receives, it forwards transactions to the block engine which write-lock
+  /// any of the accounts in the AOI.
   rpc SubscribeAccountsOfInterest (AccountsOfInterestRequest) returns (stream AccountsOfInterestUpdate) {}
 
   // Validators can subscribe to packets from the relayer and receive a multiplexed signal that contains a mixture

--- a/searcher.proto
+++ b/searcher.proto
@@ -21,7 +21,8 @@ message SendBundleResponse {
 }
 
 message PendingTxSubscriptionRequest {
-  // list of accounts to subscribe to (can be data or program accounts)
+  // list of accounts to subscribe to
+  // NOTE: the block-engine will only forward transactions that write lock the provided accounts here.
   repeated string accounts = 1;
 }
 
@@ -58,11 +59,10 @@ message GetTipAccountsResponse {
 }
 
 service SearcherService {
-  // RPC endpoint to subscribe to pending transactions.
-  // Client calls SubscribePendingTransactions with a list of public keys base58 formatted they are
-  // interested in subscribing to.
-  // Steams updates on pending transactions to client.
+  // RPC endpoint to subscribe to pending transactions. Clients can provide a list of base58 encoded accounts.
+  // Any transactions that write-lock the provided accounts will be streamed to the searcher.
   rpc SubscribePendingTransactions (PendingTxSubscriptionRequest) returns (stream PendingTxNotification) {}
+
   rpc SendBundle (SendBundleRequest) returns (SendBundleResponse) {}
 
   // Returns the next scheduled leader connected to the block engine.


### PR DESCRIPTION
- SubscribePendingTransactions only streams transactions that write lock the accounts of interest (AOI) for a given searcher