### PR TITLE
add new bundle status sub endpoint

### DIFF
--- a/bundle.proto
+++ b/bundle.proto
@@ -20,6 +20,8 @@ message BundleUuid {
 // Indicates the bundle was accepted and forwarded to a validator.
 // NOTE: A single bundle may have multiple events emitted if forwarded to many validators.
 message Accepted {
+  option deprecated = true;
+
   // Slot at which bundle was forwarded.
   uint64 slot = 1;
 
@@ -29,6 +31,8 @@ message Accepted {
 
 // Indicates the bundle was dropped and therefore not forwarded to any validator.
 message Rejected {
+  option deprecated = true;
+
   oneof reason {
     StateAuctionBidRejected state_auction_bid_rejected = 1;
     WinningBatchBidRejected winning_batch_bid_rejected = 2;
@@ -57,10 +61,12 @@ message StateAuctionBidRejected {
   optional string msg = 3;
 }
 
-// Bundle dropped due to simulation failure.
+// Bundle failed validation due to simulation failure.
 message SimulationFailure {
   // Signature of the offending transaction.
   string tx_signature = 1;
+
+  // Optional error log.
   optional string msg = 2;
 }
 
@@ -74,16 +80,25 @@ message DroppedBundle {
   string msg = 1;
 }
 
-message Finalized {}
+message Finalized {
+  option deprecated = true;
+}
+
 message Processed {
+  option deprecated = true;
+
   string validator_identity = 1;
   uint64 slot = 2;
   /// Index within the block.
   uint64 bundle_index = 3;
 }
+
 message Dropped {
+  option deprecated = true;
+
   DroppedReason reason = 1;
 }
+
 enum DroppedReason {
   BlockhashExpired = 0;
   // One or more transactions in the bundle landed on-chain, invalidating the bundle.
@@ -92,7 +107,10 @@ enum DroppedReason {
   NotFinalized = 2;
 }
 
+// NOTE: Deprecated, start using `SubscribeBundleStatuses`
 message BundleResult {
+  option deprecated = true;
+
   // Bundle's Uuid.
   string bundle_id = 1;
 
@@ -107,5 +125,67 @@ message BundleResult {
     Processed processed = 5;
     // Was accepted and forwarded by the block-engine but never landed on-chain.
     Dropped dropped = 6;
+  }
+}
+
+/** BundleStatus types */
+
+// Indicates the bundle won an auction and was forwarded to validators.
+message ForwardedToValidator {
+  // Point in time at which the bundle was forwarded.
+  uint64 slot_forwarded_at = 1;
+}
+
+// Bundle expired and pruned from mempool.
+message ExpiredAndPruned {
+  // Bundle expirations are determined by the transaction with the oldest blockhash.
+  string expired_signature = 1;
+
+  // The slot this blockhash was checked at.
+  uint64 slot_checked_at = 2;
+
+  // The expiration slot of the blockhash.
+  uint64 slot_expired_at = 3;
+}
+
+// Bundle contains transactions that have already processed on-chain.
+message ContainsAlreadyProcessedSignatures {
+  repeated string signatures = 1;
+}
+
+message Outbid {
+  // The highest bidding bundle in the auction.
+  uint64 highest_auction_bid = 1;
+
+  // Indicates whether the bundle was pruned from the mempool.
+  // e.g.
+  //  If a bundle in the batch that won the auction would invalidate this bundle then it would be pruned.
+  //  However, if this bundle was excluded from forwarding because the total forwarded bundles during the
+  //  auction window would exceed the limit, then it would be kept around in the mempool for subsequent auctions.
+  bool pruned_from_mempool = 2;
+}
+
+message BundleStatus {
+  // Bundle's Uuid.
+  string bundle_id = 1;
+
+  // Mempool region this notification came from.
+  string mempool_region = 2;
+
+  oneof result {
+    // Bundle was forwarded to validators.
+    ForwardedToValidator forwarded_to_validator = 3;
+
+    // Bundle failed simulation against the latest state of the chain.
+    SimulationFailure simulation_failure = 4;
+
+    // Bundle was outbid in an auction.
+    Outbid outbid = 5;
+
+    // Bundle expired and was pruned from the mempool.
+    ExpiredAndPruned expired_and_pruned = 6;
+
+    // Some unknown, internal error occurred.
+    InternalError internal_error = 100;
   }
 }

--- a/searcher.proto
+++ b/searcher.proto
@@ -85,7 +85,11 @@ message GetTipAccountsResponse {
   repeated string accounts = 1;
 }
 
-message SubscribeBundleResultsRequest {}
+message SubscribeBundleResultsRequest {
+    option deprecated = true;
+}
+
+message SubscribeBundleStatusesRequest {}
 
 message GetRegionsRequest {}
 message GetRegionsResponse {
@@ -100,7 +104,13 @@ message GetRegionsResponse {
 service SearcherService {
   // Searchers can invoke this endpoint to subscribe to their respective bundle results.
   // A success result would indicate the bundle won its state auction and was submitted to the validator.
-  rpc SubscribeBundleResults (SubscribeBundleResultsRequest) returns (stream bundle.BundleResult) {}
+  // NOTE: Deprecated, start using `SubscribeBundleStatuses`
+  rpc SubscribeBundleResults (SubscribeBundleResultsRequest) returns (stream bundle.BundleResult) {
+    option deprecated = true;
+  }
+
+  // Use this endpoint to subscribe to your bundle statuses.
+  rpc SubscribeBundleStatuses (SubscribeBundleStatusesRequest) returns (stream bundle.BundleStatus) {}
 
   // Subscribe to mempool transactions based on a few filters
   rpc SubscribeMempool (MempoolSubscription) returns (stream PendingTxNotification) {}


### PR DESCRIPTION
**Problem**
Current bundle results are confusing and poorly named. This is an attempt to make things more obvious. Searchers also need more insight into how to update their tips according to auction results.

**Notes**
In order to have a clean deprecation of the legacy endpoint, I've added a new endpoint. Once metrics show searchers have completely migrated, we can kill legacy.