### PR TITLE
Add proto for deshred

### DIFF
--- a/deshred.proto
+++ b/deshred.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package deshred;
+
+message Entry {
+    uint64 num_hashes = 1;
+    bytes hash = 2;
+    repeated bytes transactions = 3;
+}
+
+// tbd: we may want to add filters here
+message DeshredRequest {
+}
+
+service DeshredService {
+    rpc SubscribeToEntries(DeshredRequest) returns (stream Entry);
+}


### PR DESCRIPTION
Required for https://github.com/jito-labs/shredstream-proxy/pull/40. 

TBD if we want to keep the transactions as raw bytes or  use https://github.com/anza-xyz/agave/blob/8e258a9325a3ab2c8b3db408ec11ef932349d800/svm-conformance/proto/txn.proto 