### PR TITLE
Update urls to new docs.jito.wtf variant

### DIFF
--- a/shredstream.proto
+++ b/shredstream.proto
@@ -11,7 +11,7 @@ message Heartbeat {
   shared.Socket socket = 1;
 
   // regions for shredstream proxy to receive shreds from
-  // list of valid regions: https://jito-labs.gitbook.io/mev/systems/connecting/mainnet
+  // list of valid regions: https://docs.jito.wtf/lowlatencytxnsend/#api
   repeated string regions = 2;
 }
 
@@ -26,7 +26,7 @@ service Shredstream {
 }
 
 message TraceShred {
-  // source region, one of: https://jito-labs.gitbook.io/mev/systems/connecting/mainnet
+  // source region, one of: https://docs.jito.wtf/lowlatencytxnsend/#api
   string region = 1;
   // timestamp of creation
   google.protobuf.Timestamp created_at = 2;


### PR DESCRIPTION
Remove old links that are no longer valid for there current location https://docs.jito.wtf/lowlatencytxnsend/#api